### PR TITLE
Support JSON secrets

### DIFF
--- a/pkg/secrets_test.go
+++ b/pkg/secrets_test.go
@@ -60,6 +60,53 @@ func Test_watchOptions_populateSecret(t *testing.T) {
 	}
 }
 
+func Test_watchOptions_populateJSONSecret(t *testing.T) {
+
+	secretWithAnnotation := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{annotationGSMsecretID: "foo", annotationGSMSecretType: "json"},
+		},
+	}
+
+	successData := map[string][]byte{
+		"foo": []byte("bar"),
+		"abc": []byte("def"),
+	}
+	type fields struct {
+		data []byte
+		err  error
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		expectedData map[string][]byte
+		wantErr      bool
+	}{
+		{name: "success", fields: struct {
+			data []byte
+			err  error
+		}{data: []byte(`{"foo": "bar","abc": "def"}`), err: nil}, expectedData: successData, wantErr: false},
+
+		{name: "bad_json", fields: struct {
+			data []byte
+			err  error
+		}{data: []byte(`{"foo": bar`), err: nil}, expectedData: make(map[string][]byte), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := New("test_project")
+			o.accessSecrets = &fakeSecretsManager{data: tt.fields.data, err: tt.fields.err}
+
+			secretWithAnnotation, _, err := o.populateSecret(secretWithAnnotation, "test_project")
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("populateSecret() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, secretWithAnnotation.Data, tt.expectedData, "unexpected data set on secret")
+		})
+	}
+}
+
 func (f *fakeSecretsManager) getGoogleSecretManagerSecret(secretID, projectID string) ([]byte, error) {
 	return f.data, f.err
 }


### PR DESCRIPTION
Support parsing JSON strings from GSM secrets and map all elements to a kubernetes secret. 
This is more helpful for workloads that use `env` based secrets rather then files and need to mount multiple secrets.


### Example
GSM Value: `{"username":"admin","password":"1234"}`

Kubernetes Secret
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-secret
  namespace: adapters
  annotations:
    jenkins-x.io/gsm-secret-id: example-secret
    jenkins-x.io/gsm-type: json
```

Updated Secret:
```yaml
apiVersion: v1
data:
  password: MTIzNA==
  username: YWRtaW4=
kind: Secret
metadata:
  annotations:
    jenkins-x.io/gsm-secret-id: example-secret
    jenkins-x.io/gsm-type: json
  name: test-secret
type: Opaque

```