### PR TITLE
feat: add subscribe command to follow Secret Manager Event Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ gcloud pubsub subscriptions add-iam-policy-binding secrets.events.$CLUSTER_NAME.
     --project $SECRETS_MANAGER_PROJECT_ID
 ```
 
+### Creating Secrets
+When creating secrets, make sure to specify the topic
+```bash
+gcloud beta secrets create foo --replication-policy automatic \
+    --project $SECRETS_MANAGER_PROJECT_ID --data-file=-=my_secrets.yaml \
+    --topics "projects/${SECRETS_MANAGER_PROJECT_ID}/topics/secrets.events"
+```
+
+
 ## Install with Pubsub
 
 When following the [install instructions](#install), also set the `deployment.pubsub` values.

--- a/charts/gsm-controller/templates/cronjob.yaml
+++ b/charts/gsm-controller/templates/cronjob.yaml
@@ -17,6 +17,9 @@ spec:
               - "gsm"
             args:
               - list
+{{- if .Values.allNamespaces }}
+              - --all-namespaces
+{{- end }}
               - --project-id
               - "{{ .Values.projectID }}"
           restartPolicy: Never

--- a/charts/gsm-controller/templates/deployment.yaml
+++ b/charts/gsm-controller/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         - "gsm"
         args:
           - watch
+{{- if .Values.allNamespaces }}
+          - --all-namespaces
+{{- end }}
           - --project-id
           - "{{ .Values.projectID }}"
         env:
@@ -40,6 +43,31 @@ spec:
 {{ toYaml .Values.envFrom | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.deployment.pubsub.enabled }}
+      - name: gsm-subscribe
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - "gsm"
+        args:
+          - subscribe
+{{- if .Values.allNamespaces }}
+          - --all-namespaces
+{{- end }}
+          - --project-id
+          - "{{ .Values.projectID }}"
+          - --subscription
+          - "{{ .Values.deployment.pubsub.subscription }}"
+        env:
+{{- range $pkey, $pval := .Values.env }}
+        - name: {{ $pkey }}
+          value: {{ quote $pval }}
+{{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       serviceAccountName: gsm-sa
 {{- end -}}

--- a/charts/gsm-controller/templates/role.yaml
+++ b/charts/gsm-controller/templates/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: {{ if .Values.allNamespaces -}} Cluster {{- end -}} Role
 metadata:
   name: {{ template "fullname" . }}
 rules:

--- a/charts/gsm-controller/templates/rolebinding.yaml
+++ b/charts/gsm-controller/templates/rolebinding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: {{ if .Values.allNamespaces -}} Cluster {{- end -}} RoleBinding
 metadata:
   name: {{ template "fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: {{ if .Values.allNamespaces -}} Cluster {{- end -}} Role
   name: {{ template "fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/charts/gsm-controller/values.yaml
+++ b/charts/gsm-controller/values.yaml
@@ -1,5 +1,7 @@
 projectID:
 
+allNamespaces: false
+
 # Default values for Go projects.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -44,6 +46,10 @@ jxRequirements:
 
 deployment:
   enabled: true
+  pubsub:
+    enabled: false
+    # GCP Pub/Sub Subscription Name
+    subscription: ""
 
 cron:
   enabled: true

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -29,5 +29,6 @@ func init() {
 
 	rootCmd.AddCommand(pkg.NewCmdWatch())
 	rootCmd.AddCommand(pkg.NewCmdList())
+	rootCmd.AddCommand(pkg.NewCmdSubscribe())
 
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go v0.57.0
+	cloud.google.com/go/pubsub v1.2.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/jenkins-x/jx-logging v0.0.3
 	github.com/joho/godotenv v1.3.0
@@ -17,6 +18,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
@@ -32,6 +34,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
@@ -42,17 +45,23 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.22.3 // indirect
 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79 // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.2.0 // indirect
 	golang.org/x/net v0.0.0-20200505041828-1ed23360d12c // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 // indirect
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a // indirect
+	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
+	golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	google.golang.org/api v0.23.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/grpc v1.29.1 // indirect
 	google.golang.org/protobuf v1.22.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
+	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/utils v0.0.0-20190801114015-581e00157fb1 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,11 +13,14 @@ cloud.google.com/go v0.57.0 h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
+cloud.google.com/go/bigquery v1.4.0 h1:xE3CPsOgttP4ACBePh79zTKALtXwn/Edhcr16R5hMWU=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
+cloud.google.com/go/datastore v1.1.0 h1:/May9ojXjRkPBNVrq+oWLqmWCkr4OU5uRY29bu0mRyQ=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
+cloud.google.com/go/pubsub v1.2.0 h1:Lpy6hKgdcl7a3WGSfJIFmxmcdjSpP6OmBEfcOv1Y680=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
@@ -30,6 +33,7 @@ github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxB
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -173,6 +177,7 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -316,6 +321,7 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -323,6 +329,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -362,6 +369,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -395,8 +403,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 h1:5B6i6EAiSYyejWfvc5Rc9BbI3rzIsrrXfAQBWnYfn+w=
-golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
+golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -441,6 +449,7 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d h1:lzLdP95xJmMpwQ6LUHwrc5V7js93hTiY7gkznu0BgmY=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -526,6 +535,7 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.16.9 h1:3vCx0WX9qcg1Hv4aQ/G1tiIKectGVuimvPVTJU4VOCA=
 k8s.io/api v0.16.9/go.mod h1:Y7dZNHs1Xy0mSwSlzL9QShi6qkljnN41yR8oWCRTDe8=

--- a/pkg/secrets.go
+++ b/pkg/secrets.go
@@ -17,6 +17,7 @@ import (
 
 type secretOptions struct {
 	kubeclient    kubernetes.Interface
+	namespace     string
 	projectID     string
 	accessSecrets accessSecrets
 }
@@ -72,7 +73,7 @@ func (o secretOptions) populateSecret(secret v1.Secret, projectID string) (v1.Se
 	// Treat as JSON value and save all keys into k8s secret
 	if secret.Annotations[annotationGSMSecretType] == secretJsonType {
 		var secretMap map[string]interface{}
-		err := json.Unmarshal([]byte(secretValue), &secretMap)
+		err := json.Unmarshal(secretValue, &secretMap)
 		if err != nil {
 			return secret, false, fmt.Errorf("failed to decode JSON secret id %s in Google Secrets Manager", secretID)
 		}

--- a/pkg/subscribe.go
+++ b/pkg/subscribe.go
@@ -1,0 +1,194 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"cloud.google.com/go/pubsub"
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+
+	"github.com/jenkins-x-labs/gsm-controller/pkg/shared"
+
+	"github.com/jenkins-x/jx-logging/pkg/log"
+
+	"github.com/pkg/errors"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// SubscribeOptions are the flags for subscribe commands
+type SubscribeOptions struct {
+	Cmd           *cobra.Command
+	Args          []string
+	projectID     string
+	subID         string
+	allNamespaces bool
+}
+
+var (
+	subscribe_desc = "Subscribe to a Cloud Pub/Sub topic and update kubernetes secrets when Google Secret Manager versions are added"
+
+	subscribe_example = "gsm subscribe --project-id my-cool-gcp-project --subscription secret-events.gsm-controller"
+)
+
+// NewCmdSubscribe creates the comman
+func NewCmdSubscribe() *cobra.Command {
+	options := &SubscribeOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "subscribe",
+		Long:    subscribe_desc,
+		Short:   subscribe_desc,
+		Example: subscribe_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Cmd = cmd
+			options.Args = args
+			err := options.Run()
+			shared.CheckErr(err)
+		},
+		SuggestFor: []string{"subscribe"},
+	}
+
+	cmd.Flags().StringVarP(&options.projectID, "project-id", "", "", "The Google Project ID that contains the Google Secret Manager service")
+	cmd.Flags().StringVarP(&options.subID, "subscription", "", "", "The Google Pub/Sub subscription is set up to receive Google Secret Manager events")
+	cmd.Flags().BoolVarP(&options.allNamespaces, "all-namespaces", "", false, "Scan all namespaces when looking for secret to update")
+	return cmd
+}
+
+func (o SubscribeOptions) Run() error {
+
+	if o.projectID == "" {
+		return errors.New("missing flag project-id")
+	}
+	if o.subID == "" {
+		return errors.New("missing flag subscription")
+	}
+
+	var err error
+	secretOptions := New(o.projectID)
+
+	// Create the google secrets manager client.
+	gsm := googleSecretsManagerWrapper{
+		ctx: context.Background(),
+	}
+
+	gsm.smClient, err = secretmanager.NewClient(gsm.ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to setup secrets manager client")
+	}
+
+	secretOptions.accessSecrets = gsm
+
+	f := shared.NewFactory()
+	config, err := f.CreateKubeConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to get kubernetes config")
+	}
+
+	secretOptions.kubeclient, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "failed to create kubernetes clientset")
+	}
+
+	secretOptions.namespace = shared.CurrentNamespace()
+	if o.allNamespaces {
+		secretOptions.namespace = v1.NamespaceAll
+	}
+
+	// Die early if listing will fail later
+	_, err = secretOptions.kubeclient.CoreV1().Secrets(secretOptions.namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list secrets in namespace %s", secretOptions.namespace)
+	}
+
+	ctx := context.Background() // FIXME
+	pubsubClient, err := pubsub.NewClient(ctx, o.projectID)
+	if err != nil {
+		return errors.Wrap(err, "failed to create pubsub client")
+	}
+	defer pubsubClient.Close()
+
+	sub := pubsubClient.Subscription(o.subID)
+	err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+		secretID, err := extractSecretIDIfNewVersion(msg)
+		if err != nil {
+			log.Logger().Error(err)
+		}
+		if secretID == "" {
+			msg.Ack()
+			return
+		}
+
+		err = secretOptions.handleVersionNotification(secretID)
+		if err != nil {
+			log.Logger().Error(err)
+			if msg.DeliveryAttempt != nil && *msg.DeliveryAttempt < 3 {
+				msg.Nack()
+				return
+			}
+		}
+		msg.Ack()
+	})
+	if err != nil {
+		return errors.Wrap(err, "I want to come back to this error message")
+	}
+	return nil
+}
+
+func extractSecretIDIfNewVersion(msg *pubsub.Message) (string, error) {
+	eventType, _ := msg.Attributes["eventType"]
+	if eventType != "SECRET_VERSION_ADD" {
+		return "", nil
+	}
+	fullSecretID, ok := msg.Attributes["secretId"]
+	if !ok {
+		log.Logger().Warning("Received SECRET_VERSION_ADD with no secretId")
+		return "", nil
+	}
+
+	var projectNumber int
+	var secretID string
+	_, err := fmt.Sscanf(fullSecretID, "projects/%d/secrets/%s", &projectNumber, &secretID)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to extract final portion of secretId %q\n", fullSecretID)
+	}
+	return secretID, nil
+}
+
+func (opts secretOptions) handleVersionNotification(gsmSecretID string) error {
+
+	secret, err := opts.findSecret(gsmSecretID)
+	if err != nil {
+		return errors.Wrapf(err, "failed finding secret %q", gsmSecretID)
+	}
+	if secret == nil {
+		log.Logger().Infof("No matching secret in kubernetes for %q\n", gsmSecretID)
+		return nil
+	}
+	return opts.findSecretData(*secret)
+}
+
+func (opts secretOptions) findSecret(gsmSecretID string) (*v1.Secret, error) {
+
+	secretsList, err := opts.kubeclient.CoreV1().Secrets(opts.namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list secrets in namespace %s", opts.namespace)
+	}
+	var _ = secretsList
+	for _, secretItem := range secretsList.Items {
+		anno, ok := secretItem.Annotations[annotationGSMsecretID]
+		if !ok {
+			continue
+		}
+		if anno == gsmSecretID {
+			return &secretItem, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/subscribe_test.go
+++ b/pkg/subscribe_test.go
@@ -1,0 +1,63 @@
+package pkg
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/magiconair/properties/assert"
+)
+
+func Test_extractSecretID(t *testing.T) {
+
+	const examplePayload = `{
+		"name": "projects/827585297303/secrets/test-secret/versions/1",
+		"createTime": "2022-03-27T21:14:28.798342Z",
+		"state": "ENABLED",
+		"replicationStatus": {
+			"automatic": {}
+		},
+		"etag": "\"15db39ae618386\""
+	}`
+
+	var deliveryAttempt int = 1
+
+	msg := pubsub.Message{
+		ID:          "4257778813345930",
+		Data:        []byte(examplePayload),
+		PublishTime: time.Unix(1648928005, 0),
+		Attributes: map[string]string{
+			"dataFormat": "JSON_API_V1",
+			"eventType":  "SECRET_VERSION_ADD",
+			"secretId":   "projects/827585297303/secrets/test-secret",
+			"timestamp":  "2022-03-27T14:31:37.964139-07:00",
+			"versionId":  "projects/827585297303/secrets/test-secret/versions/2",
+		},
+		DeliveryAttempt: &deliveryAttempt,
+	}
+
+	secretID, err := extractSecretIDIfNewVersion(&msg)
+	assert.Equal(t, secretID, "test-secret")
+	assert.Equal(t, err, nil, "err is nil")
+}
+
+func Test_extractSecretID_notAddingVersion(t *testing.T) {
+
+	var deliveryAttempt int = 1
+	msg := pubsub.Message{
+		ID:          "4257778813345930",
+		Data:        []byte(`{}`),
+		PublishTime: time.Unix(1648928005, 0),
+		Attributes: map[string]string{
+			"dataFormat": "JSON_API_V1",
+			"eventType":  "SECRET_DELETE",
+			"secretId":   "projects/827585297303/secrets/test-secret",
+			"timestamp":  "2022-03-27T14:31:37.964139-07:00",
+		},
+		DeliveryAttempt: &deliveryAttempt,
+	}
+
+	secretID, err := extractSecretIDIfNewVersion(&msg)
+	assert.Equal(t, secretID, "")
+	assert.Equal(t, err, nil, "err is nil")
+}

--- a/pkg/watch.go
+++ b/pkg/watch.go
@@ -25,7 +25,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-// UpgradeOptions are the flags for delete commands
+// WatchOptions are the flags for watch commands
 type WatchOptions struct {
 	Cmd           *cobra.Command
 	Args          []string


### PR DESCRIPTION
This resolves #23.  That is, it enables near-realtime updates in the cluster when new secret versions are added by following
`SECRET_VERSION_ADD` messages under a new `subscribe` sub-command.

I've been running this in our development cluster for a couple of weeks now, and it seems to be working ok.

I've today added extra info to the docs and updated the  helm chart  today.

<details>
<summary>and checked the helm chart</summary>

```
~/src/go/gsm-controller/charts/gsm-controller (pubsub) % helm lint
==> Linting .
[WARNING] templates/cronjob.yaml: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

1 chart(s) linted, 0 chart(s) failed
~/src/go/gsm-controller/charts/gsm-controller (pubsub) % helm lint --set allNamespace=true
==> Linting .
[WARNING] templates/cronjob.yaml: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

1 chart(s) linted, 0 chart(s) failed
~/src/go/gsm-controller/charts/gsm-controller (pubsub) % helm lint --set deployment.pubsub.enabled=true
==> Linting .
[WARNING] templates/cronjob.yaml: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

1 chart(s) linted, 0 chart(s) failed
```

```
~/src/go/gsm-controller/charts/gsm-controller (pubsub) % helm template . --set projectID=fir-project-1fc35 --set deployment.pubsub.enabled=true --set deployment.pubsub.subscription=secrets.events  --set cron.schedule="23 */2 * * *"  | k apply -f -
role.rbac.authorization.k8s.io/release-name-gsm-controller unchanged
rolebinding.rbac.authorization.k8s.io/release-name-gsm-controller unchanged
deployment.apps/release-name-gsm-controller configured
Warning: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
cronjob.batch/release-name-gsm-controller configured
```

</details>

There's also an update to the helm chart to allow adding the `--all-namespaces` flag with `helm install --set allNamespaces=true`
