### PR TITLE
chore: remove resource requests from step templates

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,17 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-plugin/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-linux
           resources: {}
         - name: build-make-test

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -13,7 +13,8 @@ spec:
         stepTemplate:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-plugin/release.yaml@versionStream
           name: ""
-          resources: {}
+          resources:
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream


### PR DESCRIPTION
Updates the pipeline as described as being necessary in  https://jenkins-x.io/blog/2022/04/22/kubernetes-1.22-tekton/
i.e. sets an empty limit on the step template and moves requests from the step template to one of the individual steps.

This should hopefully fix the pipeline, which was seen failing in #24 ( https://github.com/jenkins-x/gsm-controller/pull/24#issuecomment-1979802507 )